### PR TITLE
Fix type errors and add basic UI components

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { LoadingSpinner } from "./LoadingSpinner";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  loading?: boolean;
+  icon?: React.ReactNode;
+  size?: "sm" | "md" | "lg";
+  variant?: "primary" | "success" | "danger";
+}
+
+export default function Button({
+  loading = false,
+  icon,
+  size = "md",
+  variant = "primary",
+  className = "",
+  children,
+  ...props
+}: ButtonProps) {
+  const sizeClasses = {
+    sm: "px-3 py-1 text-sm",
+    md: "px-4 py-2",
+    lg: "px-6 py-3 text-lg",
+  };
+
+  const variantClasses = {
+    primary: "bg-green-600 hover:bg-green-700 text-white",
+    success: "bg-green-600 hover:bg-green-700 text-white",
+    danger: "bg-red-600 hover:bg-red-700 text-white",
+  };
+
+  return (
+    <button
+      className={`${sizeClasses[size]} rounded-lg flex items-center justify-center gap-2 disabled:opacity-50 ${variantClasses[variant]} ${className}`}
+      disabled={loading || props.disabled}
+      {...props}
+    >
+      {loading ? <LoadingSpinner size="sm" color="text-white" /> : icon}
+      <span>{children}</span>
+    </button>
+  );
+}

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  size?: "sm" | "md" | "lg";
+  children?: React.ReactNode;
+}
+
+export function Modal({ isOpen, onClose, title, size = "md", children }: ModalProps) {
+  const sizeClasses = {
+    sm: "max-w-sm",
+    md: "max-w-md",
+    lg: "max-w-lg",
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            className={`bg-white rounded-lg shadow-lg w-full ${sizeClasses[size]}`}
+          >
+            <div className="flex justify-between items-center border-b px-4 py-2">
+              {title && <h3 className="font-semibold text-lg">{title}</h3>}
+              <button onClick={onClose} className="text-gray-500 hover:text-gray-700">&times;</button>
+            </div>
+            {children}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/app/pages/masyarakat/Gamifikasi.tsx
+++ b/app/pages/masyarakat/Gamifikasi.tsx
@@ -6,7 +6,7 @@ import Navbar from "../../components/Navbar";
 import { PointsDisplay } from "../../components/PointsDisplay";
 import { MissionCard } from "../../components/MissionCard";
 import { Modal } from "../../components/Modal";
-import { useApp } from "../../context/AppContext";
+import { useApp, showToast, type Badge } from "../../context/AppContext";
 import { leaderboard } from "../../utils/dummyData";
 import { 
   IoTrophy, 
@@ -24,7 +24,7 @@ import {
 export default function Gamifikasi() {
   const { user, missions, completeMission } = useApp();
   const [selectedTab, setSelectedTab] = useState("missions");
-  const [selectedBadge, setSelectedBadge] = useState(null);
+  const [selectedBadge, setSelectedBadge] = useState<Badge | null>(null);
   const [showBadgeModal, setShowBadgeModal] = useState(false);
   const [showRewardModal, setShowRewardModal] = useState(false);
 
@@ -34,7 +34,7 @@ export default function Gamifikasi() {
   const unlockedBadges = user.badges.filter(b => !b.achieved);
 
   // Calculate user rank in leaderboard
-  const userRank = leaderboard.findIndex(l => l.name === user.name) + 1;
+  const userRank = leaderboard.findIndex((l: any) => l.name === user.name) + 1;
 
   // Available rewards based on points
   const rewards = [
@@ -64,7 +64,7 @@ export default function Gamifikasi() {
     active: { backgroundColor: "#10b981", color: "#ffffff" }
   };
 
-  const handleBadgeClick = (badge) => {
+  const handleBadgeClick = (badge: Badge) => {
     setSelectedBadge(badge);
     setShowBadgeModal(true);
   };
@@ -341,7 +341,7 @@ export default function Gamifikasi() {
                 
                 <div className="p-6">
                   <div className="space-y-4">
-                    {leaderboard.map((player, index) => (
+                    {leaderboard.map((player: any, index: number) => (
                       <motion.div
                         key={player.id}
                         initial={{ opacity: 0, x: -20 }}
@@ -500,7 +500,7 @@ export default function Gamifikasi() {
                 <div className="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
                   <p className="text-green-800 font-medium mb-2">🎉 Badge Diraih!</p>
                   <p className="text-sm text-green-600">
-                    Diraih pada {new Date(selectedBadge.date).toLocaleDateString("id-ID")}
+                    Diraih pada {selectedBadge.date ? new Date(selectedBadge.date).toLocaleDateString("id-ID") : ""}
                   </p>
                 </div>
               ) : (

--- a/app/pages/masyarakat/JadwalSetor.tsx
+++ b/app/pages/masyarakat/JadwalSetor.tsx
@@ -7,7 +7,7 @@ import Button from "../../components/Button";
 import { Modal } from "../../components/Modal";
 import { StatusBadge } from "../../components/StatusBadge";
 import { LoadingSpinner } from "../../components/LoadingSpinner";
-import { useApp, showToast } from "../../context/AppContext";
+import { useApp, showToast, type Request } from "../../context/AppContext";
 import { wasteCategories } from "../../utils/dummyData";
 import { IoCalendar, IoScale, IoInformationCircle, IoTrash, IoAdd, IoTime, IoLocation, IoCall, IoCheckmarkCircle } from "react-icons/io5";
 
@@ -15,7 +15,7 @@ export default function JadwalSetor() {
   const { user, addRequest, getUserRequests } = useApp();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showModal, setShowModal] = useState(false);
-  const [selectedRequest, setSelectedRequest] = useState(null);
+  const [selectedRequest, setSelectedRequest] = useState<Request | null>(null);
   const [form, setForm] = useState({
     type: "pickup" as "pickup" | "deposit",
     wasteType: "",
@@ -220,7 +220,7 @@ export default function JadwalSetor() {
                     Jenis Sampah <span className="text-red-500">*</span>
                   </label>
                   <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                    {wasteCategories.map((category) => (
+                    {wasteCategories.map((category: any) => (
                       <motion.div
                         key={category.id}
                         whileHover={{ scale: 1.02 }}

--- a/app/pages/masyarakat/Riwayat.tsx
+++ b/app/pages/masyarakat/Riwayat.tsx
@@ -73,12 +73,12 @@ export default function Riwayat() {
     { id: "cancelled", label: "Dibatalkan", count: stats.cancelled }
   ];
 
-  const handleViewDetail = (request) => {
+  const handleViewDetail = (request: Request) => {
     setSelectedRequest(request);
     setShowDetailModal(true);
   };
 
-  const getStatusIcon = (status) => {
+  const getStatusIcon = (status: Request["status"]) => {
     switch (status) {
       case "completed": return "✅";
       case "pending": return "⏳";

--- a/app/pages/pengelola/Dashboard.tsx
+++ b/app/pages/pengelola/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import Navbar from "../../components/Navbar";
 import { useApp } from "../../context/AppContext";
 import CountUp from "react-countup";
+import { StatusBadge } from "../../components/StatusBadge";
 import { 
   IoArrowForward, 
   IoNotifications, 

--- a/app/pages/pengelola/JadwalPenjemputan.tsx
+++ b/app/pages/pengelola/JadwalPenjemputan.tsx
@@ -2,9 +2,10 @@
 import React, { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import Navbar from '../../components/Navbar';
-import { useApp, Request } from '../../context/AppContext';
+import { useApp, type Request } from '../../context/AppContext';
 import { StatusBadge } from '../../components/StatusBadge';
 import { Modal } from '../../components/Modal';
+import Button from '../../components/Button';
 import { 
   IoCalendar, 
   IoChevronBack, 

--- a/app/pages/pengelola/Monitoring.tsx
+++ b/app/pages/pengelola/Monitoring.tsx
@@ -18,12 +18,13 @@ import {
 import { Bar, Line } from "react-chartjs-2";
 import { WasteStockCard } from "../../components/WasteStockCard";
 import { 
-  IoStatsChart, 
-  IoPeople, 
-  IoWallet, 
-  IoCube, 
+  IoStatsChart,
+  IoPeople,
+  IoWallet,
+  IoCube,
   IoTrendingUp,
-  IoCalendarOutline
+  IoCalendarOutline,
+  IoCheckmarkCircle
 } from "react-icons/io5";
 
 ChartJS.register(
@@ -57,11 +58,11 @@ export default function Monitoring() {
   };
 
   const monthlyTrendData = {
-    labels: kpiData.monthlyTrend.map(d => d.month),
+    labels: kpiData.monthlyTrend.map((d: any) => d.month),
     datasets: [
       {
         label: "Total Sampah (kg)",
-        data: kpiData.monthlyTrend.map(d => d.waste),
+        data: kpiData.monthlyTrend.map((d: any) => d.waste),
         borderColor: "#10B981",
         backgroundColor: "rgba(16, 185, 129, 0.1)",
         fill: true,
@@ -70,7 +71,7 @@ export default function Monitoring() {
       },
       {
         label: "Pendapatan (Rp)",
-        data: kpiData.monthlyTrend.map(d => d.revenue),
+        data: kpiData.monthlyTrend.map((d: any) => d.revenue),
         borderColor: "#3B82F6",
         backgroundColor: "rgba(59, 130, 246, 0.1)",
         fill: true,

--- a/app/pages/pengelola/Penjualan.tsx
+++ b/app/pages/pengelola/Penjualan.tsx
@@ -6,11 +6,12 @@ import { useApp, showToast } from "../../context/AppContext";
 import Button from "../../components/Button";
 import { Modal } from "../../components/Modal";
 import { 
-  IoAddCircle, 
-  IoCash, 
-  IoReceipt, 
-  IoArrowUp, 
+  IoAddCircle,
+  IoCash,
+  IoReceipt,
+  IoArrowUp,
   IoArrowDown,
+  IoStatsChart,
   IoCalendarOutline,
   IoScaleOutline,
   IoBusinessOutline

--- a/app/pages/pengelola/Verifikasi.tsx
+++ b/app/pages/pengelola/Verifikasi.tsx
@@ -5,7 +5,7 @@ import Navbar from "../../components/Navbar";
 import { Modal } from "../../components/Modal";
 import Button from "../../components/Button";
 import { StatusBadge } from "../../components/StatusBadge";
-import { useApp, showToast, Request } from "../../context/AppContext";
+import { useApp, showToast, type Request } from "../../context/AppContext";
 import { 
   IoCheckmarkCircle, 
   IoCloseCircle, 
@@ -49,12 +49,15 @@ export default function Verifikasi() {
     });
 
     if (sortConfig !== null) {
+      const { key, direction } = sortConfig;
       filtered.sort((a, b) => {
-        if (a[sortConfig.key] < b[sortConfig.key]) {
-          return sortConfig.direction === 'ascending' ? -1 : 1;
+        const aVal = (a as any)[key];
+        const bVal = (b as any)[key];
+        if (aVal < bVal) {
+          return direction === 'ascending' ? -1 : 1;
         }
-        if (a[sortConfig.key] > b[sortConfig.key]) {
-          return sortConfig.direction === 'ascending' ? 1 : -1;
+        if (aVal > bVal) {
+          return direction === 'ascending' ? 1 : -1;
         }
         return 0;
       });


### PR DESCRIPTION
## Summary
- add reusable `Button` and `Modal` components
- fix missing imports and type definitions across pages
- update gamification badge modal date handling
- ensure scripts succeed with `npm run typecheck` and `npm run build`

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6889d1cfb424832f87e555058602751e