### PR TITLE
Fix TypeScript imports and props

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -1,5 +1,9 @@
 import { motion } from "framer-motion";
-import { ReactNode } from "react";
+// React exports types like `ReactNode` only for type annotations. Importing
+// them as values at runtime causes errors because CommonJS modules do not
+// expose these named exports. Use `import type` to pull in the type-only
+// definitions so they are erased during compilation.
+import type { ReactNode } from "react";
 
 interface ButtonProps {
   children: ReactNode;

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -1,5 +1,7 @@
 import { motion, AnimatePresence } from "framer-motion";
-import { ReactNode, useEffect } from "react";
+// Only `useEffect` is needed at runtime; `ReactNode` is a type-only import.
+import { useEffect } from "react";
+import type { ReactNode } from "react";
 import { IoClose } from "react-icons/io5";
 
 interface ModalProps {

--- a/app/pages/masyarakat/JadwalSetor.tsx
+++ b/app/pages/masyarakat/JadwalSetor.tsx
@@ -7,7 +7,7 @@ import Button from "../../components/Button";
 import { Modal } from "../../components/Modal";
 import { StatusBadge } from "../../components/StatusBadge";
 import { LoadingSpinner } from "../../components/LoadingSpinner";
-import { useApp, showToast } from "../../context/AppContext";
+import { useApp, showToast, type Request } from "../../context/AppContext";
 import { wasteCategories } from "../../utils/dummyData";
 import { IoCalendar, IoScale, IoInformationCircle, IoTrash, IoAdd, IoTime, IoLocation, IoCall, IoCheckmarkCircle } from "react-icons/io5";
 
@@ -15,7 +15,7 @@ export default function JadwalSetor() {
   const { user, addRequest, getUserRequests } = useApp();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showModal, setShowModal] = useState(false);
-  const [selectedRequest, setSelectedRequest] = useState(null);
+  const [selectedRequest, setSelectedRequest] = useState<Request | null>(null);
   const [form, setForm] = useState({
     type: "pickup" as "pickup" | "deposit",
     wasteType: "",
@@ -220,7 +220,7 @@ export default function JadwalSetor() {
                     Jenis Sampah <span className="text-red-500">*</span>
                   </label>
                   <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                    {wasteCategories.map((category) => (
+                    {wasteCategories.map((category: any) => (
                       <motion.div
                         key={category.id}
                         whileHover={{ scale: 1.02 }}

--- a/app/pages/masyarakat/Riwayat.tsx
+++ b/app/pages/masyarakat/Riwayat.tsx
@@ -73,12 +73,14 @@ export default function Riwayat() {
     { id: "cancelled", label: "Dibatalkan", count: stats.cancelled }
   ];
 
-  const handleViewDetail = (request) => {
+  // When a user clicks to view details, set the selected request (typed) and show modal
+  const handleViewDetail = (request: Request) => {
     setSelectedRequest(request);
     setShowDetailModal(true);
   };
 
-  const getStatusIcon = (status) => {
+  // Status badge icon; provide type for status
+  const getStatusIcon = (status: Request["status"]) => {
     switch (status) {
       case "completed": return "✅";
       case "pending": return "⏳";
@@ -298,7 +300,7 @@ export default function Riwayat() {
                   <tbody className="bg-white divide-y divide-gray-200">
                     <AnimatePresence>
                       {filteredRequests.length > 0 ? (
-                        filteredRequests.map((request, index) => (
+                        filteredRequests.map((request: Request, index: number) => (
                           <motion.tr
                             key={request.id}
                             initial={{ opacity: 0, y: 20 }}

--- a/app/pages/masyarakat/Statistik.tsx
+++ b/app/pages/masyarakat/Statistik.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+// import React from "react"; (Not needed in React 17+ with JSX transform)
+import { useState } from "react";
 import { motion } from "framer-motion";
 import Navbar from "../../components/Navbar";
 import { useApp } from "../../context/AppContext";

--- a/app/pages/pengelola/Dashboard.tsx
+++ b/app/pages/pengelola/Dashboard.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
 import Navbar from "../../components/Navbar";
 import { useApp } from "../../context/AppContext";
+import { StatusBadge } from "../../components/StatusBadge";
 import CountUp from "react-countup";
 import { 
   IoArrowForward, 

--- a/app/pages/pengelola/JadwalPenjemputan.tsx
+++ b/app/pages/pengelola/JadwalPenjemputan.tsx
@@ -2,9 +2,10 @@
 import React, { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import Navbar from '../../components/Navbar';
-import { useApp, Request } from '../../context/AppContext';
+import { useApp, showToast, type Request } from '../../context/AppContext';
 import { StatusBadge } from '../../components/StatusBadge';
 import { Modal } from '../../components/Modal';
+import Button from '../../components/Button';
 import { 
   IoCalendar, 
   IoChevronBack, 

--- a/app/pages/pengelola/Monitoring.tsx
+++ b/app/pages/pengelola/Monitoring.tsx
@@ -19,11 +19,12 @@ import { Bar, Line } from "react-chartjs-2";
 import { WasteStockCard } from "../../components/WasteStockCard";
 import { 
   IoStatsChart, 
-  IoPeople, 
-  IoWallet, 
-  IoCube, 
+  IoPeople,
+  IoWallet,
+  IoCube,
   IoTrendingUp,
-  IoCalendarOutline
+  IoCalendarOutline,
+  IoCheckmarkCircle
 } from "react-icons/io5";
 
 ChartJS.register(
@@ -57,11 +58,11 @@ export default function Monitoring() {
   };
 
   const monthlyTrendData = {
-    labels: kpiData.monthlyTrend.map(d => d.month),
+    labels: kpiData.monthlyTrend.map((d: any) => d.month),
     datasets: [
       {
         label: "Total Sampah (kg)",
-        data: kpiData.monthlyTrend.map(d => d.waste),
+        data: kpiData.monthlyTrend.map((d: any) => d.waste),
         borderColor: "#10B981",
         backgroundColor: "rgba(16, 185, 129, 0.1)",
         fill: true,
@@ -70,7 +71,7 @@ export default function Monitoring() {
       },
       {
         label: "Pendapatan (Rp)",
-        data: kpiData.monthlyTrend.map(d => d.revenue),
+        data: kpiData.monthlyTrend.map((d: any) => d.revenue),
         borderColor: "#3B82F6",
         backgroundColor: "rgba(59, 130, 246, 0.1)",
         fill: true,

--- a/app/pages/pengelola/Penjualan.tsx
+++ b/app/pages/pengelola/Penjualan.tsx
@@ -13,7 +13,8 @@ import {
   IoArrowDown,
   IoCalendarOutline,
   IoScaleOutline,
-  IoBusinessOutline
+  IoBusinessOutline,
+  IoStatsChart
 } from "react-icons/io5";
 
 // Definisikan tipe data untuk transaksi penjualan jika belum ada di AppContext

--- a/app/pages/pengelola/Verifikasi.tsx
+++ b/app/pages/pengelola/Verifikasi.tsx
@@ -5,7 +5,9 @@ import Navbar from "../../components/Navbar";
 import { Modal } from "../../components/Modal";
 import Button from "../../components/Button";
 import { StatusBadge } from "../../components/StatusBadge";
-import { useApp, showToast, Request } from "../../context/AppContext";
+// Import `Request` as a type only. Interfaces are not available at runtime,
+// and importing them as values leads to build-time warnings and SSR errors.
+import { useApp, showToast, type Request } from "../../context/AppContext";
 import { 
   IoCheckmarkCircle, 
   IoCloseCircle, 
@@ -49,12 +51,15 @@ export default function Verifikasi() {
     });
 
     if (sortConfig !== null) {
+      const { key, direction } = sortConfig;
       filtered.sort((a, b) => {
-        if (a[sortConfig.key] < b[sortConfig.key]) {
-          return sortConfig.direction === 'ascending' ? -1 : 1;
+        const aValue = a[key] as any;
+        const bValue = b[key] as any;
+        if (aValue < bValue) {
+          return direction === 'ascending' ? -1 : 1;
         }
-        if (a[sortConfig.key] > b[sortConfig.key]) {
-          return sortConfig.direction === 'ascending' ? 1 : -1;
+        if (aValue > bValue) {
+          return direction === 'ascending' ? 1 : -1;
         }
         return 0;
       });


### PR DESCRIPTION
## Summary
- use `import type` for React types
- adjust Modal imports
- refine Gamifikasi page types
- update JadwalSetor, Riwayat, and Statistik pages
- tweak dashboard and monitoring imports
- fix typings for verification flows

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_6889f78ab1d4832fbd53a8e7a5c1657a